### PR TITLE
Add MP+ parsing option

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ and changing `{demo}` to one of `diabetes`, `compas`, or `german` respectively. 
 ExplainBot.parsing_model_name = "ucinlp/{demo}-t5-small"
 # For the t5 large model
 ExplainBot.parsing_model_name = "ucinlp/{demo}-t5-large"
+# To use the MP+ strategy with a local model
+ExplainBot.parsing_model_name = "mp+:E:/models/Mistral-7B-Instruct"
 ```
 
 and the respective parsing model will be downloaded from the hub automatically.

--- a/configs/compas-config.gin
+++ b/configs/compas-config.gin
@@ -3,6 +3,7 @@
 ##########################################
 
 # the parsing model: {ucinlp/compas-t5-small, ucinlp/compas-t5-large}
+# or "mp+:E:/models/Mistral-7B-Instruct" for MP+
 ExplainBot.parsing_model_name = "ucinlp/compas-t5-small"
 
 # set skip_prompts to true for quicker startup for finetuned models

--- a/configs/diabetes-config.gin
+++ b/configs/diabetes-config.gin
@@ -4,6 +4,7 @@
 
 # Name of the parsing model: {ucinlp/diabetes-t5-small, ucinlp/diabetes-t5-large}
 # for few shot, e.g., "EleutherAI/gpt-neo-2.7B"
+# or for MP+ with a local model "mp+:E:/models/Mistral-7B-Instruct"
 ExplainBot.parsing_model_name = "ucinlp/diabetes-t5-small"
 #ExplainBot.parsing_model_name = "EleutherAI/gpt-neo-2.7B"
 

--- a/configs/german-config.gin
+++ b/configs/german-config.gin
@@ -1,5 +1,6 @@
 # ExplainBot Params
 # Name of the parsing model: {ucinlp/german-t5-small, ucinlp/german-t5-large}
+# or "mp+:E:/models/Mistral-7B-Instruct" for MP+
 ExplainBot.parsing_model_name = "ucinlp/german-t5-small"
 
 # Set skip_prompts to true for quicker startup for finetuned models

--- a/explain/decoder.py
+++ b/explain/decoder.py
@@ -62,7 +62,19 @@ class Decoder:
         if no_init:
             return
 
-        if "gpt" in parsing_model_name:
+        if parsing_model_name.startswith("mp+"):
+            from parsing.mp_plus.mp_plus_inference import get_mp_plus_predict_f
+            if ":" in parsing_model_name:
+                base_model = parsing_model_name.split(":", 1)[1]
+            else:
+                raise ValueError("mp+ parsing_model_name must be formatted as 'mp+:<model_path>'")
+
+            predict_f = get_mp_plus_predict_f(model=base_model,
+                                              use_guided_decoding=self.use_guided_dec)
+
+            def complete(prompt, grammar):
+                return predict_f(prompt=prompt, grammar=grammar)
+        elif "gpt" in parsing_model_name:
             from parsing.gpt.few_shot_inference import get_few_shot_predict_f
             predict_f = get_few_shot_predict_f(model=parsing_model_name,
                                                use_guided_decoding=self.use_guided_dec)

--- a/parsing/mp_plus/mp_plus_inference.py
+++ b/parsing/mp_plus/mp_plus_inference.py
@@ -1,0 +1,62 @@
+"""MP+ inference with template checking."""
+import gin
+from lark import Lark
+from transformers import AutoTokenizer, AutoModelForCausalLM, MaxLengthCriteria
+
+from parsing.guided_decoding.gd_logits_processor import (
+    GuidedParser,
+    GuidedDecodingLogitsProcessor,
+)
+
+
+@gin.configurable
+def get_mp_plus_predict_f(model: str, device: str = "cpu", use_guided_decoding: bool = True, max_attempts: int = 2):
+    """Gets a prediction function implementing MP+ with template checking.
+
+    Args:
+        model: Path or name of the base language model.
+        device: Device to load the model on.
+        use_guided_decoding: Whether to use guided decoding.
+        max_attempts: Number of attempts to satisfy the template check.
+    """
+    tokenizer = AutoTokenizer.from_pretrained(model)
+    base_model = AutoModelForCausalLM.from_pretrained(model)
+    base_model = base_model.to(device)
+    base_model.config.pad_token_id = base_model.config.eos_token_id
+
+    def _template_check(text: str, grammar: str) -> bool:
+        """Returns True if the generated text can be parsed by the grammar."""
+        parse_str = text.split("parsed:")[-1].split("[e]")[0] + "[e]"
+        try:
+            parser = Lark(grammar, parser="lalr")
+            parser.parse(parse_str)
+            return True
+        except Exception:
+            return False
+
+    def predict_f(prompt: str, grammar: str):
+        input_ids = tokenizer(prompt, return_tensors="pt").input_ids.to(device)
+        parser = None
+        if use_guided_decoding:
+            parser = GuidedParser(grammar, tokenizer, model="gpt")
+            processor = GuidedDecodingLogitsProcessor(parser, input_ids.shape[1])
+        stopping = MaxLengthCriteria(max_length=200)
+        last_decoded = ""
+        for _ in range(max_attempts):
+            if use_guided_decoding:
+                generation = base_model.greedy_search(
+                    input_ids,
+                    logits_processor=processor,
+                    eos_token_id=parser.eos_token,
+                )
+            else:
+                generation = base_model.greedy_search(
+                    input_ids,
+                    stopping_criteria=stopping,
+                )
+            last_decoded = tokenizer.decode(generation[0])
+            if _template_check(last_decoded, grammar):
+                break
+        return {"generation": last_decoded}
+
+    return predict_f


### PR DESCRIPTION
## Summary
- implement MP+ inference via template checking
- support `mp+` parsing model prefix in decoder
- document MP+ usage
- add MP+ notes to configs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'inflect')*

------
https://chatgpt.com/codex/tasks/task_e_684d7d2c6518832aa4e1a02e845432e2